### PR TITLE
Await::RESOLVE/Await::REJECT can only be called with 0/1 argument

### DIFF
--- a/await-generator/src/SOFe/AwaitGenerator/PromiseState.php
+++ b/await-generator/src/SOFe/AwaitGenerator/PromiseState.php
@@ -22,8 +22,10 @@ declare(strict_types=1);
 
 namespace SOFe\AwaitGenerator;
 
+use InvalidArgumentException;
 use Throwable;
 use function assert;
+use function func_num_args;
 
 abstract class PromiseState{
 	public const STATE_PENDING = 0;
@@ -46,12 +48,20 @@ abstract class PromiseState{
 	public function resolve($value) : void{
 		assert($this->state === self::STATE_PENDING);
 
+		if(func_num_args() > 1){
+			throw new InvalidArgumentException("Await::RESOLVE output called with more than one parameter, but only one value can be resolved");
+		}
+
 		$this->state = self::STATE_RESOLVED;
 		$this->resolved = $value;
 	}
 
 	public function reject(Throwable $value) : void{
 		assert($this->state === self::STATE_PENDING);
+
+		if(func_num_args() > 1){
+			throw new InvalidArgumentException("Await::REJECT output called with more than one parameter, but only one value can be resolved");
+		}
 
 		$this->state = self::STATE_REJECTED;
 		$this->rejected = $value;

--- a/tests/SOFe/AwaitGenerator/AwaitTest.php
+++ b/tests/SOFe/AwaitGenerator/AwaitTest.php
@@ -137,6 +137,18 @@ class AwaitTest extends TestCase{
 		});
 	}
 
+	public function testExcessResolve() : void{
+		Await::f2c(function() : Generator{
+			yield Await::REJECT;
+		}, function(){
+			self::assertTrue(false, "unexpected resolve call");
+		}, function($ex) : void{
+			self::assertInstanceOf(AwaitException::class, $ex);
+			/** @var AwaitException $ex */
+			self::assertEquals("Cannot yield Await::REJECT without yielding Await::RESOLVE first; they must be yielded in pairs", $ex->getMessage());
+		});
+	}
+
 	public function testDoubleReject() : void{
 		$firstRejectOk = false;
 		Await::f2c(function() use (&$firstRejectOk) : Generator{


### PR DESCRIPTION
This is technically not a BC break since resolving/rejecting more than one parameter has never been allowed.