### PR TITLE
Added Await::promise() and deprecated constant yields

### DIFF
--- a/await-generator/src/SOFe/AwaitGenerator/Await.php
+++ b/await-generator/src/SOFe/AwaitGenerator/Await.php
@@ -188,6 +188,21 @@ class Await extends PromiseState{
 	}
 
 	/**
+	 * Executes a callback-style async function using JavaScript Promise-like API.
+	 *
+	 * This *differs* from JavaScript Promise in that $closure is NOT executed
+	 * until it is yielded and processed by an Await runtime.
+	 */
+	public static function promise(Closure $closure) : Generator{
+		$resolve = yield Await::RESOLVE;
+		$reject = yield Await::REJECT;
+
+		$closure($resolve, $reject);
+		return yield Await::ONCE;
+	}
+
+
+	/**
 	 * A wrapper around wakeup() to convert deep recursion to tail recursion
 	 *
 	 * @param callable|null $executor

--- a/await-generator/src/SOFe/AwaitGenerator/Await.php
+++ b/await-generator/src/SOFe/AwaitGenerator/Await.php
@@ -198,6 +198,9 @@ class Await extends PromiseState{
 	 *
 	 * This *differs* from JavaScript Promise in that $closure is NOT executed
 	 * until it is yielded and processed by an Await runtime.
+	 *
+	 * @param Closure(Closure(T): void, Closure(Throwable): void): void $closure
+	 * @return Generator<mixed, Await::RESOLVE|null|Await::RESOLVE_MULTI|Await::REJECT|Await::ONCE|Await::ALL|Await::RACE|Generator, mixed, T>
 	 */
 	public static function promise(Closure $closure) : Generator{
 		$resolve = yield Await::RESOLVE;

--- a/await-generator/src/SOFe/AwaitGenerator/Await.php
+++ b/await-generator/src/SOFe/AwaitGenerator/Await.php
@@ -88,8 +88,8 @@ class Await extends PromiseState{
 	 * @param callable            $closure
 	 * @phpstan-param callable(): Generator<mixed, Await::RESOLVE|null|Await::RESOLVE_MULTI|Await::REJECT|Await::ONCE|Await::ALL|Await::RACE|Generator, mixed, T> $closure
 	 * @param callable|null       $onComplete
-	 * @phpstan-param (callable(T): void)|null  $onComplete
-	 * @param callable[]|callable $catches
+	 * @phpstan-param (callable(T): void)|null $onComplete This argument has been deprecated. Append the call to the generator closure instead.
+	 * @param callable[]|callable $catches This argument has been deprecated. Use a try-catch block in the generator closure instead.
 	 * @phpstan-param array<string, callable(Throwable): void>|callable(Throwable): void $catches
 	 *
 	 * @return Await<T>
@@ -104,8 +104,8 @@ class Await extends PromiseState{
 	 * @param Generator           $generator
 	 * @phpstan-param Generator<mixed, Await::RESOLVE|null|Await::RESOLVE_MULTI|Await::REJECT|Await::ONCE|Await::ALL|Await::RACE|Generator, mixed, T> $generator
 	 * @param callable|null       $onComplete
-	 * @phpstan-param (callable(T): void)|null  $onComplete
-	 * @param callable[]|callable $catches
+	 * @phpstan-param (callable(T): void)|null $onComplete This argument has been deprecated. Append the call to the generator closure instead.
+	 * @param callable[]|callable $catches This argument has been deprecated. Use a try-catch block in the generator instead.
 	 * @phpstan-param array<string, callable(Throwable): void>|callable(Throwable): void $catches
 	 *
 	 * @return Await<T>

--- a/await-generator/src/SOFe/AwaitGenerator/Await.php
+++ b/await-generator/src/SOFe/AwaitGenerator/Await.php
@@ -39,11 +39,17 @@ use function is_callable;
  * @template T
  */
 class Await extends PromiseState{
+	/** @internal Use `Await::promise` instead */
 	public const RESOLVE = "resolve";
+	/** @internal Use `Await::promise` instead */
 	public const RESOLVE_MULTI = [Await::RESOLVE];
+	/** @internal Use `Await::promise` instead */
 	public const REJECT = "reject";
+	/** @internal Use `Await::promise` instead */
 	public const ONCE = "once";
+	/** @internal Use `Await::all` instead */
 	public const ALL = "all";
+	/** @internal Use `Await::race` instead */
 	public const RACE = "race";
 
 	/**

--- a/book/src/await-gen.md
+++ b/book/src/await-gen.md
@@ -1,10 +1,7 @@
 # Awaiting generators
 Since every async function is implemented as a generator function,
 simply calling it will not have any effects.
-Instead, you have to `yield` the generator.
-await-generator will still resume your function
-when the yielded generator finished running,
-and send you the value returned by the yielded generator.
+Instead, you have to `yield from` the generator.
 
 ```php
 function a(): Generator {
@@ -13,19 +10,18 @@ function a(): Generator {
 }
 
 function main(): Generator {
-	$a = yield $this->a();
+	$a = yield from $this->a();
 	var_dump($a);
 }
 ```
 
-It is easy to forget to `yield` the generator.
+It is easy to forget to `yield from` the generator.
 <!-- TODO provide suggestions -->
 <!-- TODO does phpstan detect this? -->
 
 ## Handling errors
-await-generator will make your `yield` throw an exception
+`yield from` will throw an exception
 if the generator function you called threw an exception.
-You can use try-catch to handle these exceptions.
 
 ```php
 function err(): Generator {
@@ -35,7 +31,7 @@ function err(): Generator {
 
 function main(): Generator {
 	try {
-		yield err();
+		yield from err();
 	} catch(Exception $e) {
 		var_dump($e->getMessage()); // string(4) "Test"
 	}

--- a/book/src/f2c-g2c.md
+++ b/book/src/f2c-g2c.md
@@ -15,24 +15,10 @@ Sometimes we want to write the generator function as a closure
 and pass it directly:
 
 ```php
-Await::f2c(function(): \Generator {
+Await::f2c(function(): Generator {
 	// some async logic
 });
 ```
 
-The return/throw value of the generator can be handled in callback style too:
-
-```php
-Await::f2c(function(): \Generator {
-	0 && yield;
-	if(rand() % 2 == 1) {
-		return 1;
-	} else {
-		throw new \Exception("random");
-	}
-}, function($value) {
-	var_dump($value); // int(1)
-}, function($ex) {
-	var_dump($ex->getMessage()); // string(6) "random"
-});
-```
+You can also use `Await::g2c`/`Await::f2c`
+to schedule a separate async function in the background.

--- a/book/src/generators.md
+++ b/book/src/generators.md
@@ -94,6 +94,39 @@ function qux(): Generator {
 }
 ```
 
+## Calling another generator
+You can call another generator in a generator,
+which will pass through all the yielded values
+and send back all the sent values
+using the `yield from` syntax.
+The `yield from` expression resolves to the return value of the generator.
+
+```php
+function test($value): Generator {
+	$send = yield $value;
+	return $send;
+}
+
+function main(): Generator {
+	$a = yield from test(1);
+	$b = yield from test(2);
+	var_dump($a + $b);
+}
+
+$generator = main();
+$generator->rewind();
+var_dump($generator->current());
+$generator->send(3);
+var_dump($generator->current());
+$generator->send(4);
+```
+
+```
+int(1)
+int(2)
+int(7)
+```
+
 ## Hacking generators
 Sometimes we want to make a generator function that does not yield at all.
 In that case, you can write `0 && yield;` at the start of the function;

--- a/tests/SOFe/AwaitGenerator/AwaitTest.php
+++ b/tests/SOFe/AwaitGenerator/AwaitTest.php
@@ -804,15 +804,10 @@ class AwaitTest extends TestCase{
 	public function testSameLaterRejectImmediateResolve() : void{
 		$rand = 0x12345678;
 		$ex = new DummyException();
-		self::assertImmediateResolve(function() use ($rand, $ex) : Generator{
-			$resolve = yield Await::RESOLVE;
-			$reject = yield Await::REJECT;
-			// they are the same pair!
+		self::assertImmediateResolve(fn() => Await::promise(function($resolve, $reject) use($rand, $ex) {
 			self::voidCallbackLater($ex, $reject);
 			self::voidCallbackImmediate($rand, $resolve);
-			$once = yield Await::ONCE;
-			return $once;
-		}, $rand);
+		}), $rand);
 		self::callLater();
 	}
 
@@ -900,11 +895,11 @@ class AwaitTest extends TestCase{
 	}
 
 	private static function generatorReturnLater($ret) : Generator{
-		return yield self::voidCallbackLater($ret, yield) => Await::ONCE;
+		return yield from Await::promise(fn($resolve) => self::voidCallbackLater($ret, $resolve));
 	}
 
 	private static function generatorThrowLater(Throwable $ex) : Generator{
-		yield self::voidCallbackLater(null, yield) => Await::ONCE;
+		yield from Await::promise(fn($resolve) => self::voidCallbackLater(null, $resolve));
 		throw $ex;
 	}
 
@@ -915,6 +910,6 @@ class AwaitTest extends TestCase{
 	}
 
 	private static function generatorVoidLater() : Generator{
-		yield self::voidCallbackLater(null, yield) => Await::ONCE;
+		yield from Await::promise(fn($resolve) => self::voidCallbackLater(null, $resolve));
 	}
 }


### PR DESCRIPTION
The `yield Await::ONCE` syntax causes constant confusion to new users.It would be simpler to use an API similar to JavaScript Promise, which simply creates a promise by passing a resolve/reject closure.

Note that `Await::promise` *differs* from JavaScript Promise in that $closure is *NOT* executed until it is yielded and processed by an Await runtime. This behaviour is *intentional*, because the await-generator philosophy is that a generator must either be `Await::g2c`ed (to execute in background) or `yield`ed (or `yield from`) so that it starts executor. A generator that has not been yielded *should not* do anything, This is because no side effects would be expected before the yield/`g2c` starts since the suspension points are transparent to the caller.